### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,266 +1,267 @@
-Revision history for Test-Aggregate
+Revision history for Perl distribution Test-Aggregate
 
-0.368  2013-08-14
-        - Fix tests on windows
+0.368 2013-08-14
+    - Fix tests on windows
 
-0.367  2013-08-13
-        - Improve Test::Aggregate::Nested error handling:
-          Don't treat undef as a failure;
-          Show a warning and let Test::More::subtest() determine the result.
-          This solves the false negative reported in
-          https://rt.cpan.org/Public/Bug/Display.html?id=87240
-          Thanks to the venerable Andreas J. König for reporting!
-        - Add more tests.
-        - Actually include previously added tests to the dist
-          (Where are you Dist::Zilla?)
+0.367 2013-08-13
+    - Improve Test::Aggregate::Nested error handling:
+      Don't treat undef as a failure;
+      Show a warning and let Test::More::subtest() determine the result.
+      This solves the false negative reported in
+      https://rt.cpan.org/Public/Bug/Display.html?id=87240
+      Thanks to the venerable Andreas J. König for reporting!
+    - Add more tests.
+    - Actually include previously added tests to the dist
+      (Where are you Dist::Zilla?)
 
-0.366  2013-07-11
-        - Update metadata; Re-release to reindex with additional permissions
+0.366 2013-07-11
+    - Update metadata; Re-release to reindex with additional permissions
 
-0.365  2013-07-10
-        - Avoid printing unnecessary "ok - "'s diag()s when they are passing,
-          and when the 'verbose' option is set to 0.
-            - The problem was that the $verbose option was hard-coded as
-              '2' deep inside the module.
-        - Catch errors in tests under Test::Aggregate::Nested; report as ok(0)
-        - Pod fixes
-        - Update repository metadata
+0.365 2013-07-10
+    - Avoid printing unnecessary "ok - "'s diag()s when they are passing,
+      and when the 'verbose' option is set to 0.
+        - The problem was that the $verbose option was hard-coded as
+          '2' deep inside the module.
+    - Catch errors in tests under Test::Aggregate::Nested; report as ok(0)
+    - Pod fixes
+    - Update repository metadata
 
-0.364  04/12/2010
-        - Allow skipping the rest of a test using
-            plan skip_all => $reason
+0.364 2010-12-04
+    - Allow skipping the rest of a test using
+        plan skip_all => $reason
 
-0.363  24/11/2009
-        - Pass current test name to setup and teardown.
+0.363 2009-11-24
+    - Pass current test name to setup and teardown.
 
-0.362  17/11/2009
-        - Removed broken "check_plan" from Test::Aggregate.  It was always
-          dodgy and really doesn't contribute much and the latest release
-          broke with 'no_plan'.  We now warn if we see this.
-        - Minimum Test::More is now 0.94.  This gives us more robust nested
-          TAP.
+0.362 2009-11-17
+    - Removed broken "check_plan" from Test::Aggregate.  It was always
+      dodgy and really doesn't contribute much and the latest release
+      broke with 'no_plan'.  We now warn if we see this.
+    - Minimum Test::More is now 0.94.  This gives us more robust nested
+      TAP.
 
-0.361   20/10/2009
-        - Keep Makefile.PL in synch.  Reported by Andreas Koenig
-          (https://rt.cpan.org/Ticket/Display.html?id=50673)
+0.361 2009-10-20
+    - Keep Makefile.PL in synch.  Reported by Andreas Koenig
+      (https://rt.cpan.org/Ticket/Display.html?id=50673)
 
-0.36    18/10/2009
-        - Mark for production.
-        - Removed 'dump.t' files in tests.
-        - Improve Test::Aggregate::Nested docs.
-        - Removed some dead code.
-        - Suppress multiple plans (#48352, Chisel Wright)
+0.36 2009-10-18
+    - Mark for production.
+    - Removed 'dump.t' files in tests.
+    - Improve Test::Aggregate::Nested docs.
+    - Removed some dead code.
+    - Suppress multiple plans (#48352, Chisel Wright)
 
-0.35_07 19/08/2009
-        - Added missing files to MANIFEST.
+0.35_07 2009-08-19
+    - Added missing files to MANIFEST.
 
-0.35_06 28/06/2009
-        - Added support for nested TAP via Test::Aggregate::Nested.
-        - I really, really need to get a real release out.
+0.35_06 2009-06-28
+    - Added support for nested TAP via Test::Aggregate::Nested.
+    - I really, really need to get a real release out.
 
-0.35_05 20/05/2009
-        - Removed bogus test file throwing my counts off.  No wonder all tests
-          were failing for people!
-        - Remove development lib links.
+0.35_05 2009-05-20
+    - Removed bogus test file throwing my counts off.  No wonder all tests
+      were failing for people!
+    - Remove development lib links.
 
-0.35_04 Unreleased.
-        - Unlink dump files in tests.
+    [ 0.35_04 Unreleased ]
+    - Unlink dump files in tests.
 
-0.35_03 15/05/2009
-        - Don't run done_testing() in tests if it doesn't exist.
+0.35_03 2009-05-15
+    - Don't run done_testing() in tests if it doesn't exist.
 
-0.35_02 14/05/2009
-        - Deprecate tests run in BEGIN/END/CHECK/INIT.
-          See http://use.perl.org/~Ovid/journal/38974 for more information.
-        - check_plan, if set, is now done at the end of each test instead of
-          the end of all tests.
-        - Make it work with the Test::Builder 0.88 and previous versions.
-        - Embed the calling test script name in a comment at the top of the
-          dump file.
-        - Fix a doc typo (thanks to Offer Kaye for the report)
-        - Cleaned up some tests.
+0.35_02 2009-05-14
+    - Deprecate tests run in BEGIN/END/CHECK/INIT.
+      See http://use.perl.org/~Ovid/journal/38974 for more information.
+    - check_plan, if set, is now done at the end of each test instead of
+      the end of all tests.
+    - Make it work with the Test::Builder 0.88 and previous versions.
+    - Embed the calling test script name in a comment at the top of the
+      dump file.
+    - Fix a doc typo (thanks to Offer Kaye for the report)
+    - Cleaned up some tests.
 
-0.35_01 18/11/2008
-        - Make 'exit()' scream loudly if called.
-        - Move Test::Aggregate::Builder globals into a hashref in the object.
-          Further encapsulation to come later.
-        - Export &run_this_test_program from Test::Aggregate to make dump
-          files cleaner.
-        - Reorganize the test suite to avoid false negatives.
+0.35_01 2008-11-18
+    - Make 'exit()' scream loudly if called.
+    - Move Test::Aggregate::Builder globals into a hashref in the object.
+      Further encapsulation to come later.
+    - Export &run_this_test_program from Test::Aggregate to make dump
+      files cleaner.
+    - Reorganize the test suite to avoid false negatives.
 
-0.35    27/10/2008
-        - Move from developer to production version number.
-        - Add 'use Test::Aggregate' to the dump file.
-        - Updated the docs to explain that the C<Test::More> functions are
-          re-exported.
+0.35 2008-10-27
+    - Move from developer to production version number.
+    - Add 'use Test::Aggregate' to the dump file.
+    - Updated the docs to explain that the C<Test::More> functions are
+      re-exported.
 
-0.34_09 15/10/2008
-        - Added 'tests' key to the constructor.  This is an optional method of
-          identifying which tests you wish to aggregate.
+0.34_09 2008-10-15
+    - Added 'tests' key to the constructor.  This is an optional method of
+      identifying which tests you wish to aggregate.
 
-0.34_08 14/10/2008
-        - Much refactoring of internals.  This moves some autogenerated code
-          directly into the Test::Aggregate namespace and Test::Aggregate->run
-          calls this code directly to better synchronize behavior between
-          running the code and running the dump file.  This has the side
-          effect of making individual test files much easier to find and read
-          and makes the 'dump.t' file smaller.
-        - Fixed a bug where a test dieing could cause the wrong test to be
-          reported as failing.
-        - Removed %INC from the list of localized variables.  Localazing this
-          doesn't remove the code from the symbol tables, so attempting to
-          later reload this code leads to strange failures.
+0.34_08 2008-10-14
+    - Much refactoring of internals.  This moves some autogenerated code
+      directly into the Test::Aggregate namespace and Test::Aggregate->run
+      calls this code directly to better synchronize behavior between
+      running the code and running the dump file.  This has the side
+      effect of making individual test files much easier to find and read
+      and makes the 'dump.t' file smaller.
+    - Fixed a bug where a test dieing could cause the wrong test to be
+      reported as failing.
+    - Removed %INC from the list of localized variables.  Localazing this
+      doesn't remove the code from the symbol tables, so attempting to
+      later reload this code leads to strange failures.
 
-0.34_07 13/10/2008
-        - Fixed bug where dump file tests would fail if check_plan is set to
-          true.
-        - Common environment variables are now localized on a "per test file"
-          basis.
-        - Make the "5.006" requirement explicit in the Build.PL and
-          Makefile.PL scripts.
+0.34_07 2008-10-13
+    - Fixed bug where dump file tests would fail if check_plan is set to
+      true.
+    - Common environment variables are now localized on a "per test file"
+      basis.
+    - Make the "5.006" requirement explicit in the Build.PL and
+      Makefile.PL scripts.
 
-0.34_06 21/10/2008
-        - Skip findbin test if FindBin < 1.47.  Seems to cause test failures
-          as FindBin *appears* to be getting confused by the setting of $0,
-          but I'm not sure yet as I don't have an older Perl installed.
+0.34_06 2008-10-21
+    - Skip findbin test if FindBin < 1.47.  Seems to cause test failures
+      as FindBin *appears* to be getting confused by the setting of $0,
+      but I'm not sure yet as I don't have an older Perl installed.
 
-0.34_05 19/09/2008
-        - Changed 'unlink dump.t or die' to a warn (tests only).
+0.34_05 2008-09-19
+    - Changed 'unlink dump.t or die' to a warn (tests only).
 
-0.34_03 18/09/2008
-        - Fixed major regression where --dry was eliminated and test counts (X
-          of Y tests) were eliminated.
-        - Automatically build a proper Makefile.PL.
-        - Add FindBin to the dependencies.
-        - Major refactoring of internals to make debugging dump files much
-          cleaner and easier (and reduce their size, while we're at it).
+0.34_03 2008-09-18
+    - Fixed major regression where --dry was eliminated and test counts (X
+      of Y tests) were eliminated.
+    - Automatically build a proper Makefile.PL.
+    - Add FindBin to the dependencies.
+    - Major refactoring of internals to make debugging dump files much
+      cleaner and easier (and reduce their size, while we're at it).
 
-0.34_03 15/09/2008
-        - Again cleaned up dump file generated when running tests.  Need to
-          guard against that better.  Also removed it from the MANIFEST.
+0.34_03 2008-09-15
+    - Again cleaned up dump file generated when running tests.  Need to
+      guard against that better.  Also removed it from the MANIFEST.
 
-0.34_02 14/09/2008
-        - Allow skip_all tests.
+0.34_02 2008-09-14
+    - Allow skip_all tests.
 
-0.34_01 04/09/2008
-        - Add an option to reinitialize FindBin for each aggregated test.
-        - Don't emit a plan when not running any tests.
+0.34_01 2008-09-04
+    - Add an option to reinitialize FindBin for each aggregated test.
+    - Don't emit a plan when not running any tests.
 
-0.33    03/09/2008
-        - Upload 0.32_05 as a non-development release.
+0.33 2008-09-03
+    - Upload 0.32_05 as a non-development release.
 
-0.32_02 03/08/2008
-        - Added Test::Aggregate::Builder to the MANIFEST.
+0.32_02 2008-08-03
+    - Added Test::Aggregate::Builder to the MANIFEST.
 
-0.32_01 03/08/2008
-        - Added line directives to aggregated tests to ensure that
-          Test::Builder::ok can now report the correct filename and line
-          number.
-        - set_filenames => 1 is now the default behavior.
-        - Split the Test::Builder override into its own package.
+0.32_01 2008-08-03
+    - Added line directives to aggregated tests to ensure that
+      Test::Builder::ok can now report the correct filename and line
+      number.
+    - set_filenames => 1 is now the default behavior.
+    - Split the Test::Builder override into its own package.
 
-0.31    22/07/2008
-        - Minor bugfix to play well with Test::Most (reset test failure when
-          forcing failure after test program eval).
+0.31 2008-07-22
+    - Minor bugfix to play well with Test::Most (reset test failure when
+      forcing failure after test program eval).
 
-0.30    17/07/2008
-        - Resolved final (known) bug with Test::NoWarnings.  If it's loaded
-          before the plan is set, make sure we still adjust the plan.
+0.30 2008-07-17
+    - Resolved final (known) bug with Test::NoWarnings.  If it's loaded
+      before the plan is set, make sure we still adjust the plan.
 
-0.24    15/07/2008
-        - Document the 'local $@' problem in "COMMON PITFALLS".
-        - Ensure that dump file also forces a failure outside the eval().
-        - Make sure that the TEST_AGGREGATE environment variable is set in a
-          BEGIN block.  Otherwise, code relying on this variable might get
-          called too soon to check it.
+0.24 2008-07-15
+    - Document the 'local $@' problem in "COMMON PITFALLS".
+    - Ensure that dump file also forces a failure outside the eval().
+    - Make sure that the TEST_AGGREGATE environment variable is set in a
+      BEGIN block.  Otherwise, code relying on this variable might get
+      called too soon to check it.
 
-0.23    12/06/08
-        - Reluctantly added Test::NoWarnings as a dependency to avoid test
-          failures.
+0.23 2008-06-12
+    - Reluctantly added Test::NoWarnings as a dependency to avoid test
+      failures.
 
-0.22    11/06/2008
-        - If we really do have an error from the eval listed below, make sure
-          we have a failing test to accompany it.  Otherwise, tests which die
-          might be reported as passing.
+0.22 2008-06-11
+    - If we really do have an error from the eval listed below, make sure
+      we have a failing test to accompany it.  Otherwise, tests which die
+      might be reported as passing.
 
-0.21    11/06/2008
-        - Wrap ->run_the_tests() calls in an eval so that one package failing
-          is less likely to stop the other tests from running.
+0.21 2008-06-11
+    - Wrap ->run_the_tests() calls in an eval so that one package failing
+      is less likely to stop the other tests from running.
 
-0.20    04/04/2008
-        - 'startup' and 'shutdown' are no longer called in BEGIN/END blocks.
-          They were getting rather tricky due to timing issues.  This may
-          change in the future.
-        - Added 'check_plan' attribute.  This allows us to verify the plan of
-          those test programs which have one (experimental).
-        - Added 'test_nowarnings' attribute.  This can be used to disable
-          C<Test::NoWarnings>.
-        - Reworked some of the Test::Builder changes to minimize the amount of
-          monkey patching and to make the intent clearer.
-        - Verbosity is now 0, 1, or 2.  If '1' is verbosity, we only show test
-          failures.
-        - We now maintain the Build.PL and Makefile.PL files separately due to
-          issues with the latter not supporting the features of the former.
-        - Eliminated some bogus tests added which were only there to show you
-          which aggtest was being run.
-        - Fixed the dates in the Changes file.
+0.20 2008-04-04
+    - 'startup' and 'shutdown' are no longer called in BEGIN/END blocks.
+      They were getting rather tricky due to timing issues.  This may
+      change in the future.
+    - Added 'check_plan' attribute.  This allows us to verify the plan of
+      those test programs which have one (experimental).
+    - Added 'test_nowarnings' attribute.  This can be used to disable
+      C<Test::NoWarnings>.
+    - Reworked some of the Test::Builder changes to minimize the amount of
+      monkey patching and to make the intent clearer.
+    - Verbosity is now 0, 1, or 2.  If '1' is verbosity, we only show test
+      failures.
+    - We now maintain the Build.PL and Makefile.PL files separately due to
+      issues with the latter not supporting the features of the former.
+    - Eliminated some bogus tests added which were only there to show you
+      which aggtest was being run.
+    - Fixed the dates in the Changes file.
 
-0.11    15/03/2008
-        - Fixed bug where not having Data::Dump::Streamer installed would
-          cause test failures if 'dump' was not set.  Reported by numerous
-          CPAN smoke testers :)
-        - Added optional (and experimental) Perl::Tidy support.
-        - Fixed broken 'verbose'.  The 'ok/not ok' message was being output
-          regardless of verbose setting.
+0.11 2008-03-15
+    - Fixed bug where not having Data::Dump::Streamer installed would
+      cause test failures if 'dump' was not set.  Reported by numerous
+      CPAN smoke testers :)
+    - Added optional (and experimental) Perl::Tidy support.
+    - Fixed broken 'verbose'.  The 'ok/not ok' message was being output
+      regardless of verbose setting.
 
-0.10   13/03/2008
-        - Added startup, shutdown, setup, teardown attributes.
-        - Add more tests.
-        - Clean up dump file generated by tests.
+0.10 2008-03-13
+    - Added startup, shutdown, setup, teardown attributes.
+    - Add more tests.
+    - Clean up dump file generated by tests.
 
-0.08    09/03/2008
-        - Require Test::Builder 0.74.
-        - We now diag ok/not ok messages for each test program.  This makes it
-          much easier to figure out which program failed.
-        - Fixed warnings when 'dump' was not set.  Thanks to RENEEB for the
-          bug report [http://rt.cpan.org/Ticket/Display.html?id=32443]
+0.08 2008-03-09
+    - Require Test::Builder 0.74.
+    - We now diag ok/not ok messages for each test program.  This makes it
+      much easier to figure out which program failed.
+    - Fixed warnings when 'dump' was not set.  Thanks to RENEEB for the
+      bug report [http://rt.cpan.org/Ticket/Display.html?id=32443]
 
-0.07    05/03/2008
-        - Added TEST_AGGREGATE environment variable.
+0.07 2008-03-05
+    - Added TEST_AGGREGATE environment variable.
 
-0.06    15/01/2007
-        - Use an END block instead of adding Test::Builder::DESTROY.  This is
-          cleaner and doesn't override the DESTROY provided by Test::Most.
+0.06 2007-01-15
+    - Use an END block instead of adding Test::Builder::DESTROY.  This is
+      cleaner and doesn't override the DESTROY provided by Test::Most.
 
-0.05    29/12/2007
-        - Fixed an open in aggtests/boilerplate.t which made the module fail
-          with 5.005.
+0.05 2007-12-29
+    - Fixed an open in aggtests/boilerplate.t which made the module fail
+      with 5.005.
 
-0.04    29/12/2007
-        - Fixed open() to work with versions of Perl < 5.6
-        - More extensive overriding of Test::Builder internals.  I tried to
-          subclass it but it's not designed to be subclassed and much pain
-          ensued.
-        - Dump file now has all "run_the_tests" lines at the top and the
-          packages below them.  This makes for easier debugging as you can
-          comment out test packages one by one simply by commenting out its
-          "run_the_tests" line.
-        - Fixed bug where runtests() would run tests in a different order from
-          the dump file.
-        - Fixed bug where Test::NoWarnings would try to run a test after the
-          plan was output.
+0.04 2007-12-29
+    - Fixed open() to work with versions of Perl < 5.6
+    - More extensive overriding of Test::Builder internals.  I tried to
+      subclass it but it's not designed to be subclassed and much pain
+      ensued.
+    - Dump file now has all "run_the_tests" lines at the top and the
+      packages below them.  This makes for easier debugging as you can
+      comment out test packages one by one simply by commenting out its
+      "run_the_tests" line.
+    - Fixed bug where runtests() would run tests in a different order from
+      the dump file.
+    - Fixed bug where Test::NoWarnings would try to run a test after the
+      plan was output.
 
-0.03    29/11/2007
-        - Moved 'skip_all' files into the t/ directory. Aggregating them
-          fails.  mauzo (http://use.perl.org/~mauzo/)
+0.03 2007-11-29
+    - Moved 'skip_all' files into the t/ directory. Aggregating them
+      fails.  mauzo (http://use.perl.org/~mauzo/)
 
-0.02    26/11/2007
-        - Fixed bug where multiple tests setting an explicit plan in the use
-          statement would cause failures.
-        - Attempt to work around 'unauthorized release' issue on the CPAN.
-          Simply declaring the 'Test::Builder' package directly is frowned
-          upon.
-        - Update the docs to warn explain 'shared variable' warnings.
+0.02 2007-11-26
+    - Fixed bug where multiple tests setting an explicit plan in the use
+      statement would cause failures.
+    - Attempt to work around 'unauthorized release' issue on the CPAN.
+      Simply declaring the 'Test::Builder' package directly is frowned
+      upon.
+    - Update the docs to warn explain 'shared variable' warnings.
 
-0.01    25/11/2007
-        First version.  Run test suites faster.
+0.01 2007-11-25
+    First version.  Run test suites faster.
+


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org),
which is where I saw your module listed :-)

Cheers,
Neil

You can check the status of [all of your other dists](http://changes.cpanhq.org/author/RWSTAUNER), though after this you've only got one that's non-conformant.
