### PR TITLE
Bail out if Test::Builder is too recent.

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,10 +1,16 @@
 #!perl 
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 
 use lib 't/lib';
 
 BEGIN {
+    my $v = $Test::More::VERSION;
+    cmp_ok($v, '<', 1.3, 'Compatible Test::Builer')
+        or BAIL_OUT(<< "__BAIL_OUT__");
+This module only works with Test::More version < 1.3, but you have $v.
+__BAIL_OUT__
+
     use_ok('Test::Aggregate')       or die;
     use_ok('Slow::Loading::Module') or die;
 }


### PR DESCRIPTION
There's no easy way to support Test::Builder v1.3+. For the time being, just bail out.